### PR TITLE
Refactor data preparation and LGBM classifier to use Pandas instead o…

### DIFF
--- a/data_preparation.ipynb
+++ b/data_preparation.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 108,
    "id": "0f1133c9",
    "metadata": {},
    "outputs": [
@@ -10,6 +10,8 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
+      "The autoreload extension is already loaded. To reload it, use:\n",
+      "  %reload_ext autoreload\n",
       "Path (/Users/rik/Documents/VU/DMT/DataMiningTechniquesA2) already exists in sys.path\n"
      ]
     }
@@ -22,26 +24,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 113,
    "id": "8f2ee368",
    "metadata": {},
    "outputs": [],
    "source": [
     "import polars as pl\n",
+    "import pandas as pd\n",
     "from data_preparation import DataPreparer"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 110,
    "id": "1316859d",
    "metadata": {},
    "outputs": [
     {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/pandas/core/dtypes/astype.py:133: RuntimeWarning: overflow encountered in cast\n",
+      "  return arr.astype(dtype, copy=True)\n",
+      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/pandas/core/dtypes/astype.py:133: RuntimeWarning: overflow encountered in cast\n",
+      "  return arr.astype(dtype, copy=True)\n"
+     ]
+    },
+    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Data uploaded to data/training_set_processed.parquet\n",
+      "Data uploaded to data/training_set_processed.parquet\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/pandas/core/dtypes/astype.py:133: RuntimeWarning: overflow encountered in cast\n",
+      "  return arr.astype(dtype, copy=True)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
       "Data uploaded to data/test_set_processed.parquet\n"
      ]
     }
@@ -54,161 +81,13 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "76a4d11d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_df = pl.read_parquet(\"data/training_set_processed.parquet\")\n",
-    "test_df = pl.read_parquet(\"data/test_set_processed.parquet\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "id": "ee4175bc",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (4_958_347, 96)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>srch_id</th><th>site_id</th><th>visitor_location_country_id</th><th>visitor_hist_starrating</th><th>visitor_hist_adr_usd</th><th>prop_country_id</th><th>prop_id</th><th>prop_starrating</th><th>prop_review_score</th><th>prop_brand_bool</th><th>prop_location_score1</th><th>prop_location_score2</th><th>prop_log_historical_price</th><th>position</th><th>price_usd</th><th>promotion_flag</th><th>srch_destination_id</th><th>srch_length_of_stay</th><th>srch_booking_window</th><th>srch_adults_count</th><th>srch_children_count</th><th>srch_room_count</th><th>srch_saturday_night_bool</th><th>srch_query_affinity_score</th><th>orig_destination_distance</th><th>random_bool</th><th>comp1_rate</th><th>comp1_inv</th><th>comp1_rate_percent_diff</th><th>comp2_rate</th><th>comp2_inv</th><th>comp2_rate_percent_diff</th><th>comp3_rate</th><th>comp3_inv</th><th>comp3_rate_percent_diff</th><th>comp4_rate</th><th>comp4_inv</th><th>&hellip;</th><th>is_night</th><th>is_spring</th><th>is_summer</th><th>is_autumn</th><th>is_winter</th><th>is_weekend</th><th>visitor_hist_starrating_flag</th><th>visitor_hist_adr_usd_flag</th><th>prop_review_score_flag</th><th>srch_query_affinity_score_flag</th><th>orig_destination_distance_flag</th><th>comp1_rate_flag</th><th>comp2_rate_flag</th><th>comp3_rate_flag</th><th>comp4_rate_flag</th><th>comp5_rate_flag</th><th>comp6_rate_flag</th><th>comp7_rate_flag</th><th>comp8_rate_flag</th><th>comp1_inv_flag</th><th>comp2_inv_flag</th><th>comp3_inv_flag</th><th>comp4_inv_flag</th><th>comp5_inv_flag</th><th>comp6_inv_flag</th><th>comp7_inv_flag</th><th>comp8_inv_flag</th><th>comp1_rate_percent_diff_flag</th><th>comp2_rate_percent_diff_flag</th><th>comp3_rate_percent_diff_flag</th><th>comp4_rate_percent_diff_flag</th><th>comp5_rate_percent_diff_flag</th><th>comp6_rate_percent_diff_flag</th><th>comp7_rate_percent_diff_flag</th><th>comp8_rate_percent_diff_flag</th><th>prop_review_score_zero_flag</th><th>prop_log_historical_price_zero_flag</th></tr><tr><td>i32</td><td>i8</td><td>i16</td><td>f32</td><td>f32</td><td>i16</td><td>i32</td><td>i8</td><td>f32</td><td>i8</td><td>f32</td><td>f32</td><td>f32</td><td>i8</td><td>f32</td><td>i8</td><td>i16</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f32</td><td>f32</td><td>i8</td><td>i8</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>&hellip;</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td></tr></thead><tbody><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>893</td><td>3</td><td>3.5</td><td>1</td><td>2.83</td><td>0.0438</td><td>4.95</td><td>27</td><td>104.769997</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>10404</td><td>4</td><td>4.0</td><td>1</td><td>2.2</td><td>0.0149</td><td>5.03</td><td>26</td><td>170.740005</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>21315</td><td>3</td><td>4.5</td><td>1</td><td>2.2</td><td>0.0245</td><td>4.92</td><td>21</td><td>179.800003</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>27348</td><td>2</td><td>4.0</td><td>1</td><td>2.83</td><td>0.0125</td><td>4.39</td><td>34</td><td>602.77002</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>-1</td><td>0</td><td>5</td><td>-1</td><td>0</td><td>5</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>29604</td><td>4</td><td>3.5</td><td>1</td><td>2.64</td><td>0.1241</td><td>4.93</td><td>4</td><td>143.580002</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>77700</td><td>3</td><td>4.0</td><td>1</td><td>1.61</td><td>0.0471</td><td>null</td><td>2</td><td>118.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.919983</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>88083</td><td>3</td><td>4.0</td><td>1</td><td>1.95</td><td>0.152</td><td>null</td><td>3</td><td>89.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>553.140015</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>94508</td><td>3</td><td>3.5</td><td>1</td><td>1.1</td><td>0.0164</td><td>null</td><td>4</td><td>99.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>544.429993</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>128360</td><td>3</td><td>5.0</td><td>1</td><td>1.95</td><td>0.0662</td><td>null</td><td>1</td><td>139.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.380005</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>134949</td><td>3</td><td>2.5</td><td>1</td><td>1.1</td><td>null</td><td>null</td><td>6</td><td>61.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>583.25</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (4_958_347, 96)\n",
-       "┌─────────┬─────────┬────────────┬────────────┬───┬────────────┬───────────┬───────────┬───────────┐\n",
-       "│ srch_id ┆ site_id ┆ visitor_lo ┆ visitor_hi ┆ … ┆ comp7_rate ┆ comp8_rat ┆ prop_revi ┆ prop_log_ │\n",
-       "│ ---     ┆ ---     ┆ cation_cou ┆ st_starrat ┆   ┆ _percent_d ┆ e_percent ┆ ew_score_ ┆ historica │\n",
-       "│ i32     ┆ i8      ┆ ntry_id    ┆ ing        ┆   ┆ iff_flag   ┆ _diff_fla ┆ zero_flag ┆ l_price_z │\n",
-       "│         ┆         ┆ ---        ┆ ---        ┆   ┆ ---        ┆ g         ┆ ---       ┆ ero…      │\n",
-       "│         ┆         ┆ i16        ┆ f32        ┆   ┆ i8         ┆ ---       ┆ i8        ┆ ---       │\n",
-       "│         ┆         ┆            ┆            ┆   ┆            ┆ i8        ┆           ┆ i8        │\n",
-       "╞═════════╪═════════╪════════════╪════════════╪═══╪════════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 0         │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 0         │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 0         │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 0         ┆ 0         │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 0         │\n",
-       "│ …       ┆ …       ┆ …          ┆ …          ┆ … ┆ …          ┆ …         ┆ …         ┆ …         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "└─────────┴─────────┴────────────┴────────────┴───┴────────────┴───────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train_df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 9,
-   "id": "f6359426",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (4_958_347, 97)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>srch_id</th><th>site_id</th><th>visitor_location_country_id</th><th>visitor_hist_starrating</th><th>visitor_hist_adr_usd</th><th>prop_country_id</th><th>prop_id</th><th>prop_starrating</th><th>prop_review_score</th><th>prop_brand_bool</th><th>prop_location_score1</th><th>prop_location_score2</th><th>prop_log_historical_price</th><th>position</th><th>price_usd</th><th>promotion_flag</th><th>srch_destination_id</th><th>srch_length_of_stay</th><th>srch_booking_window</th><th>srch_adults_count</th><th>srch_children_count</th><th>srch_room_count</th><th>srch_saturday_night_bool</th><th>srch_query_affinity_score</th><th>orig_destination_distance</th><th>random_bool</th><th>comp1_rate</th><th>comp1_inv</th><th>comp1_rate_percent_diff</th><th>comp2_rate</th><th>comp2_inv</th><th>comp2_rate_percent_diff</th><th>comp3_rate</th><th>comp3_inv</th><th>comp3_rate_percent_diff</th><th>comp4_rate</th><th>comp4_inv</th><th>&hellip;</th><th>is_spring</th><th>is_summer</th><th>is_autumn</th><th>is_winter</th><th>is_weekend</th><th>visitor_hist_starrating_flag</th><th>visitor_hist_adr_usd_flag</th><th>prop_review_score_flag</th><th>srch_query_affinity_score_flag</th><th>orig_destination_distance_flag</th><th>comp1_rate_flag</th><th>comp2_rate_flag</th><th>comp3_rate_flag</th><th>comp4_rate_flag</th><th>comp5_rate_flag</th><th>comp6_rate_flag</th><th>comp7_rate_flag</th><th>comp8_rate_flag</th><th>comp1_inv_flag</th><th>comp2_inv_flag</th><th>comp3_inv_flag</th><th>comp4_inv_flag</th><th>comp5_inv_flag</th><th>comp6_inv_flag</th><th>comp7_inv_flag</th><th>comp8_inv_flag</th><th>comp1_rate_percent_diff_flag</th><th>comp2_rate_percent_diff_flag</th><th>comp3_rate_percent_diff_flag</th><th>comp4_rate_percent_diff_flag</th><th>comp5_rate_percent_diff_flag</th><th>comp6_rate_percent_diff_flag</th><th>comp7_rate_percent_diff_flag</th><th>comp8_rate_percent_diff_flag</th><th>prop_review_score_zero_flag</th><th>prop_log_historical_price_zero_flag</th><th>srch_id_count</th></tr><tr><td>i32</td><td>i8</td><td>i16</td><td>f32</td><td>f32</td><td>i16</td><td>i32</td><td>i8</td><td>f32</td><td>i8</td><td>f32</td><td>f32</td><td>f32</td><td>i8</td><td>f32</td><td>i8</td><td>i16</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f32</td><td>f32</td><td>i8</td><td>i8</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>&hellip;</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>u32</td></tr></thead><tbody><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>893</td><td>3</td><td>3.5</td><td>1</td><td>2.83</td><td>0.0438</td><td>4.95</td><td>27</td><td>104.769997</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>28</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>10404</td><td>4</td><td>4.0</td><td>1</td><td>2.2</td><td>0.0149</td><td>5.03</td><td>26</td><td>170.740005</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>28</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>21315</td><td>3</td><td>4.5</td><td>1</td><td>2.2</td><td>0.0245</td><td>4.92</td><td>21</td><td>179.800003</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>28</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>27348</td><td>2</td><td>4.0</td><td>1</td><td>2.83</td><td>0.0125</td><td>4.39</td><td>34</td><td>602.77002</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>-1</td><td>0</td><td>5</td><td>-1</td><td>0</td><td>5</td><td>null</td><td>null</td><td>&hellip;</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>0</td><td>28</td></tr><tr><td>1</td><td>12</td><td>187</td><td>null</td><td>null</td><td>219</td><td>29604</td><td>4</td><td>3.5</td><td>1</td><td>2.64</td><td>0.1241</td><td>4.93</td><td>4</td><td>143.580002</td><td>0</td><td>23246</td><td>1</td><td>0</td><td>4</td><td>0</td><td>1</td><td>1</td><td>null</td><td>null</td><td>1</td><td>null</td><td>null</td><td>null</td><td>0</td><td>0</td><td>null</td><td>0</td><td>0</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>1</td><td>0</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>0</td><td>28</td></tr><tr><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td><td>&hellip;</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>77700</td><td>3</td><td>4.0</td><td>1</td><td>1.61</td><td>0.0471</td><td>null</td><td>2</td><td>118.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.919983</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>6</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>88083</td><td>3</td><td>4.0</td><td>1</td><td>1.95</td><td>0.152</td><td>null</td><td>3</td><td>89.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>553.140015</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>6</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>94508</td><td>3</td><td>3.5</td><td>1</td><td>1.1</td><td>0.0164</td><td>null</td><td>4</td><td>99.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>544.429993</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>6</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>128360</td><td>3</td><td>5.0</td><td>1</td><td>1.95</td><td>0.0662</td><td>null</td><td>1</td><td>139.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.380005</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>6</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>134949</td><td>3</td><td>2.5</td><td>1</td><td>1.1</td><td>null</td><td>null</td><td>6</td><td>61.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>583.25</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td><td>6</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (4_958_347, 97)\n",
-       "┌─────────┬─────────┬────────────┬────────────┬───┬────────────┬───────────┬───────────┬───────────┐\n",
-       "│ srch_id ┆ site_id ┆ visitor_lo ┆ visitor_hi ┆ … ┆ comp8_rate ┆ prop_revi ┆ prop_log_ ┆ srch_id_c │\n",
-       "│ ---     ┆ ---     ┆ cation_cou ┆ st_starrat ┆   ┆ _percent_d ┆ ew_score_ ┆ historica ┆ ount      │\n",
-       "│ i32     ┆ i8      ┆ ntry_id    ┆ ing        ┆   ┆ iff_flag   ┆ zero_flag ┆ l_price_z ┆ ---       │\n",
-       "│         ┆         ┆ ---        ┆ ---        ┆   ┆ ---        ┆ ---       ┆ ero…      ┆ u32       │\n",
-       "│         ┆         ┆ i16        ┆ f32        ┆   ┆ i8         ┆ i8        ┆ ---       ┆           │\n",
-       "│         ┆         ┆            ┆            ┆   ┆            ┆           ┆ i8        ┆           │\n",
-       "╞═════════╪═════════╪════════════╪════════════╪═══╪════════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 0         ┆ 28        │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 0         ┆ 28        │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 0         ┆ 28        │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 0          ┆ 0         ┆ 0         ┆ 28        │\n",
-       "│ 1       ┆ 12      ┆ 187        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 0         ┆ 28        │\n",
-       "│ …       ┆ …       ┆ …          ┆ …          ┆ … ┆ …          ┆ …         ┆ …         ┆ …         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 1         ┆ 6         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 1         ┆ 6         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 1         ┆ 6         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 1         ┆ 6         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 0         ┆ 1         ┆ 6         │\n",
-       "└─────────┴─────────┴────────────┴────────────┴───┴────────────┴───────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 9,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train_df.with_columns(pl.col(\"srch_id\").count().over(\"srch_id\").alias(\"srch_id_count\"))"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 11,
-   "id": "61127e99",
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
-       "</style>\n",
-       "<small>shape: (6, 96)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>srch_id</th><th>site_id</th><th>visitor_location_country_id</th><th>visitor_hist_starrating</th><th>visitor_hist_adr_usd</th><th>prop_country_id</th><th>prop_id</th><th>prop_starrating</th><th>prop_review_score</th><th>prop_brand_bool</th><th>prop_location_score1</th><th>prop_location_score2</th><th>prop_log_historical_price</th><th>position</th><th>price_usd</th><th>promotion_flag</th><th>srch_destination_id</th><th>srch_length_of_stay</th><th>srch_booking_window</th><th>srch_adults_count</th><th>srch_children_count</th><th>srch_room_count</th><th>srch_saturday_night_bool</th><th>srch_query_affinity_score</th><th>orig_destination_distance</th><th>random_bool</th><th>comp1_rate</th><th>comp1_inv</th><th>comp1_rate_percent_diff</th><th>comp2_rate</th><th>comp2_inv</th><th>comp2_rate_percent_diff</th><th>comp3_rate</th><th>comp3_inv</th><th>comp3_rate_percent_diff</th><th>comp4_rate</th><th>comp4_inv</th><th>&hellip;</th><th>is_night</th><th>is_spring</th><th>is_summer</th><th>is_autumn</th><th>is_winter</th><th>is_weekend</th><th>visitor_hist_starrating_flag</th><th>visitor_hist_adr_usd_flag</th><th>prop_review_score_flag</th><th>srch_query_affinity_score_flag</th><th>orig_destination_distance_flag</th><th>comp1_rate_flag</th><th>comp2_rate_flag</th><th>comp3_rate_flag</th><th>comp4_rate_flag</th><th>comp5_rate_flag</th><th>comp6_rate_flag</th><th>comp7_rate_flag</th><th>comp8_rate_flag</th><th>comp1_inv_flag</th><th>comp2_inv_flag</th><th>comp3_inv_flag</th><th>comp4_inv_flag</th><th>comp5_inv_flag</th><th>comp6_inv_flag</th><th>comp7_inv_flag</th><th>comp8_inv_flag</th><th>comp1_rate_percent_diff_flag</th><th>comp2_rate_percent_diff_flag</th><th>comp3_rate_percent_diff_flag</th><th>comp4_rate_percent_diff_flag</th><th>comp5_rate_percent_diff_flag</th><th>comp6_rate_percent_diff_flag</th><th>comp7_rate_percent_diff_flag</th><th>comp8_rate_percent_diff_flag</th><th>prop_review_score_zero_flag</th><th>prop_log_historical_price_zero_flag</th></tr><tr><td>i32</td><td>i8</td><td>i16</td><td>f32</td><td>f32</td><td>i16</td><td>i32</td><td>i8</td><td>f32</td><td>i8</td><td>f32</td><td>f32</td><td>f32</td><td>i8</td><td>f32</td><td>i8</td><td>i16</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>f32</td><td>f32</td><td>i8</td><td>i8</td><td>i8</td><td>i16</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>i32</td><td>i8</td><td>i8</td><td>&hellip;</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td><td>i8</td></tr></thead><tbody><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>55110</td><td>3</td><td>1.0</td><td>1</td><td>2.2</td><td>null</td><td>null</td><td>7</td><td>109.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>512.780029</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>77700</td><td>3</td><td>4.0</td><td>1</td><td>1.61</td><td>0.0471</td><td>null</td><td>2</td><td>118.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.919983</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>88083</td><td>3</td><td>4.0</td><td>1</td><td>1.95</td><td>0.152</td><td>null</td><td>3</td><td>89.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>553.140015</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>94508</td><td>3</td><td>3.5</td><td>1</td><td>1.1</td><td>0.0164</td><td>null</td><td>4</td><td>99.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>544.429993</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>128360</td><td>3</td><td>5.0</td><td>1</td><td>1.95</td><td>0.0662</td><td>null</td><td>1</td><td>139.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>550.380005</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr><tr><td>332785</td><td>5</td><td>219</td><td>null</td><td>null</td><td>219</td><td>134949</td><td>3</td><td>2.5</td><td>1</td><td>1.1</td><td>null</td><td>null</td><td>6</td><td>61.0</td><td>0</td><td>16974</td><td>1</td><td>21</td><td>3</td><td>0</td><td>1</td><td>0</td><td>null</td><td>583.25</td><td>0</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>null</td><td>&hellip;</td><td>0</td><td>0</td><td>1</td><td>0</td><td>0</td><td>0</td><td>1</td><td>1</td><td>0</td><td>1</td><td>0</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>1</td><td>0</td><td>1</td></tr></tbody></table></div>"
-      ],
-      "text/plain": [
-       "shape: (6, 96)\n",
-       "┌─────────┬─────────┬────────────┬────────────┬───┬────────────┬───────────┬───────────┬───────────┐\n",
-       "│ srch_id ┆ site_id ┆ visitor_lo ┆ visitor_hi ┆ … ┆ comp7_rate ┆ comp8_rat ┆ prop_revi ┆ prop_log_ │\n",
-       "│ ---     ┆ ---     ┆ cation_cou ┆ st_starrat ┆   ┆ _percent_d ┆ e_percent ┆ ew_score_ ┆ historica │\n",
-       "│ i32     ┆ i8      ┆ ntry_id    ┆ ing        ┆   ┆ iff_flag   ┆ _diff_fla ┆ zero_flag ┆ l_price_z │\n",
-       "│         ┆         ┆ ---        ┆ ---        ┆   ┆ ---        ┆ g         ┆ ---       ┆ ero…      │\n",
-       "│         ┆         ┆ i16        ┆ f32        ┆   ┆ i8         ┆ ---       ┆ i8        ┆ ---       │\n",
-       "│         ┆         ┆            ┆            ┆   ┆            ┆ i8        ┆           ┆ i8        │\n",
-       "╞═════════╪═════════╪════════════╪════════════╪═══╪════════════╪═══════════╪═══════════╪═══════════╡\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "│ 332785  ┆ 5       ┆ 219        ┆ null       ┆ … ┆ 1          ┆ 1         ┆ 0         ┆ 1         │\n",
-       "└─────────┴─────────┴────────────┴────────────┴───┴────────────┴───────────┴───────────┴───────────┘"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "train_df.filter(pl.col(\"srch_id\") == 332785)"
+    "train_df = pd.read_parquet(\"data/training_set_processed.parquet\")\n",
+    "test_df = pd.read_parquet(\"data/test_set_processed.parquet\")"
    ]
   }
  ],

--- a/lgbm_classifier.ipynb
+++ b/lgbm_classifier.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "id": "3f1266d2",
    "metadata": {},
    "outputs": [
@@ -24,30 +24,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "id": "fecde38d",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import polars as pl\n",
+    "import pandas as pd\n",
     "from lgbm_classifier import LGBMClassifierModel\n",
     "from lightgbm import LGBMClassifier"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "id": "c15dc4d9",
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_df = pl.read_parquet(\"data/training_set_processed.parquet\")\n",
-    "test_df = pl.read_parquet(\"data/test_set_processed.parquet\")"
+    "train_df = pd.read_parquet(\"data/training_set_processed.parquet\")\n",
+    "test_df = pd.read_parquet(\"data/test_set_processed.parquet\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "id": "03aa93eb",
    "metadata": {},
    "outputs": [],
@@ -64,7 +64,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "id": "b11d26f8",
    "metadata": {},
    "outputs": [
@@ -75,52 +75,49 @@
       "[LightGBM] [Warning] Categorical features with more bins than the configured maximum bin number found.\n",
       "[LightGBM] [Warning] For categorical features, max_bin and max_bin_by_feature may be ignored with a large number of categories.\n",
       "[LightGBM] [Info] Number of positive: 177546, number of negative: 3789131\n",
-      "[LightGBM] [Info] Auto-choosing row-wise multi-threading, the overhead of testing was 0.283486 seconds.\n",
+      "[LightGBM] [Info] Auto-choosing row-wise multi-threading, the overhead of testing was 0.287477 seconds.\n",
       "You can set `force_row_wise=true` to remove the overhead.\n",
       "And if memory is not enough, you can set `force_col_wise=true`.\n",
-      "[LightGBM] [Info] Total Bins 11309\n",
+      "[LightGBM] [Info] Total Bins 11308\n",
       "[LightGBM] [Info] Number of data points in the train set: 3966677, number of used features: 92\n",
       "[LightGBM] [Info] [binary:BoostFromScore]: pavg=0.044759 -> initscore=-3.060662\n",
       "[LightGBM] [Info] Start training from score -3.060662\n",
       "Training until validation scores don't improve for 50 rounds\n",
-      "[20]\tvalid_0's auc: 0.709532\tvalid_0's binary_logloss: 0.171343\n",
-      "[40]\tvalid_0's auc: 0.718033\tvalid_0's binary_logloss: 0.168817\n",
-      "[60]\tvalid_0's auc: 0.72369\tvalid_0's binary_logloss: 0.167677\n",
-      "[80]\tvalid_0's auc: 0.727872\tvalid_0's binary_logloss: 0.166962\n",
-      "[100]\tvalid_0's auc: 0.730954\tvalid_0's binary_logloss: 0.166444\n",
-      "[120]\tvalid_0's auc: 0.73324\tvalid_0's binary_logloss: 0.166058\n",
-      "[140]\tvalid_0's auc: 0.734868\tvalid_0's binary_logloss: 0.165792\n",
-      "[160]\tvalid_0's auc: 0.736122\tvalid_0's binary_logloss: 0.165574\n",
-      "[180]\tvalid_0's auc: 0.737127\tvalid_0's binary_logloss: 0.165403\n",
-      "[200]\tvalid_0's auc: 0.738003\tvalid_0's binary_logloss: 0.165253\n",
-      "[220]\tvalid_0's auc: 0.738759\tvalid_0's binary_logloss: 0.165115\n",
-      "[240]\tvalid_0's auc: 0.7393\tvalid_0's binary_logloss: 0.165012\n",
-      "[260]\tvalid_0's auc: 0.739815\tvalid_0's binary_logloss: 0.164917\n",
-      "[280]\tvalid_0's auc: 0.740271\tvalid_0's binary_logloss: 0.164836\n",
-      "[300]\tvalid_0's auc: 0.740588\tvalid_0's binary_logloss: 0.164773\n",
-      "[320]\tvalid_0's auc: 0.7409\tvalid_0's binary_logloss: 0.164715\n",
-      "[340]\tvalid_0's auc: 0.74117\tvalid_0's binary_logloss: 0.164665\n",
-      "[360]\tvalid_0's auc: 0.741333\tvalid_0's binary_logloss: 0.164633\n",
-      "[380]\tvalid_0's auc: 0.741567\tvalid_0's binary_logloss: 0.164591\n",
-      "[400]\tvalid_0's auc: 0.741723\tvalid_0's binary_logloss: 0.164559\n",
-      "[420]\tvalid_0's auc: 0.741854\tvalid_0's binary_logloss: 0.164533\n",
-      "[440]\tvalid_0's auc: 0.742069\tvalid_0's binary_logloss: 0.164501\n",
-      "[460]\tvalid_0's auc: 0.742156\tvalid_0's binary_logloss: 0.164481\n",
-      "[480]\tvalid_0's auc: 0.742216\tvalid_0's binary_logloss: 0.164467\n",
-      "[500]\tvalid_0's auc: 0.742362\tvalid_0's binary_logloss: 0.164443\n",
-      "[520]\tvalid_0's auc: 0.742407\tvalid_0's binary_logloss: 0.164434\n",
-      "[540]\tvalid_0's auc: 0.742419\tvalid_0's binary_logloss: 0.16443\n",
-      "[560]\tvalid_0's auc: 0.742452\tvalid_0's binary_logloss: 0.164425\n",
-      "[580]\tvalid_0's auc: 0.742469\tvalid_0's binary_logloss: 0.16442\n",
-      "[600]\tvalid_0's auc: 0.742475\tvalid_0's binary_logloss: 0.164415\n",
-      "[620]\tvalid_0's auc: 0.742509\tvalid_0's binary_logloss: 0.164408\n",
-      "[640]\tvalid_0's auc: 0.742577\tvalid_0's binary_logloss: 0.164401\n",
-      "[660]\tvalid_0's auc: 0.74259\tvalid_0's binary_logloss: 0.164397\n",
-      "[680]\tvalid_0's auc: 0.742663\tvalid_0's binary_logloss: 0.164389\n",
-      "[700]\tvalid_0's auc: 0.742603\tvalid_0's binary_logloss: 0.164397\n",
-      "[720]\tvalid_0's auc: 0.742593\tvalid_0's binary_logloss: 0.164399\n",
+      "[20]\tvalid_0's auc: 0.709612\tvalid_0's binary_logloss: 0.171356\n",
+      "[40]\tvalid_0's auc: 0.718063\tvalid_0's binary_logloss: 0.168822\n",
+      "[60]\tvalid_0's auc: 0.72385\tvalid_0's binary_logloss: 0.167681\n",
+      "[80]\tvalid_0's auc: 0.727879\tvalid_0's binary_logloss: 0.16696\n",
+      "[100]\tvalid_0's auc: 0.730869\tvalid_0's binary_logloss: 0.166469\n",
+      "[120]\tvalid_0's auc: 0.732976\tvalid_0's binary_logloss: 0.166102\n",
+      "[140]\tvalid_0's auc: 0.734646\tvalid_0's binary_logloss: 0.165816\n",
+      "[160]\tvalid_0's auc: 0.735942\tvalid_0's binary_logloss: 0.1656\n",
+      "[180]\tvalid_0's auc: 0.737019\tvalid_0's binary_logloss: 0.165415\n",
+      "[200]\tvalid_0's auc: 0.737925\tvalid_0's binary_logloss: 0.165258\n",
+      "[220]\tvalid_0's auc: 0.738702\tvalid_0's binary_logloss: 0.165119\n",
+      "[240]\tvalid_0's auc: 0.739261\tvalid_0's binary_logloss: 0.16502\n",
+      "[260]\tvalid_0's auc: 0.739743\tvalid_0's binary_logloss: 0.164929\n",
+      "[280]\tvalid_0's auc: 0.740157\tvalid_0's binary_logloss: 0.164849\n",
+      "[300]\tvalid_0's auc: 0.740509\tvalid_0's binary_logloss: 0.164784\n",
+      "[320]\tvalid_0's auc: 0.740822\tvalid_0's binary_logloss: 0.164723\n",
+      "[340]\tvalid_0's auc: 0.74108\tvalid_0's binary_logloss: 0.164675\n",
+      "[360]\tvalid_0's auc: 0.741352\tvalid_0's binary_logloss: 0.164625\n",
+      "[380]\tvalid_0's auc: 0.74152\tvalid_0's binary_logloss: 0.164591\n",
+      "[400]\tvalid_0's auc: 0.741767\tvalid_0's binary_logloss: 0.164551\n",
+      "[420]\tvalid_0's auc: 0.741886\tvalid_0's binary_logloss: 0.164527\n",
+      "[440]\tvalid_0's auc: 0.742031\tvalid_0's binary_logloss: 0.164502\n",
+      "[460]\tvalid_0's auc: 0.742127\tvalid_0's binary_logloss: 0.16448\n",
+      "[480]\tvalid_0's auc: 0.742234\tvalid_0's binary_logloss: 0.164463\n",
+      "[500]\tvalid_0's auc: 0.742307\tvalid_0's binary_logloss: 0.164448\n",
+      "[520]\tvalid_0's auc: 0.7424\tvalid_0's binary_logloss: 0.16443\n",
+      "[540]\tvalid_0's auc: 0.742504\tvalid_0's binary_logloss: 0.164414\n",
+      "[560]\tvalid_0's auc: 0.742625\tvalid_0's binary_logloss: 0.164394\n",
+      "[580]\tvalid_0's auc: 0.742693\tvalid_0's binary_logloss: 0.164382\n",
+      "[600]\tvalid_0's auc: 0.74271\tvalid_0's binary_logloss: 0.164378\n",
+      "[620]\tvalid_0's auc: 0.742715\tvalid_0's binary_logloss: 0.164378\n",
+      "[640]\tvalid_0's auc: 0.742722\tvalid_0's binary_logloss: 0.164373\n",
+      "[660]\tvalid_0's auc: 0.742704\tvalid_0's binary_logloss: 0.164377\n",
       "Early stopping, best iteration is:\n",
-      "[675]\tvalid_0's auc: 0.742678\tvalid_0's binary_logloss: 0.164386\n"
+      "[615]\tvalid_0's auc: 0.742729\tvalid_0's binary_logloss: 0.164376\n"
      ]
     }
    ],
@@ -135,47 +132,43 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "id": "7a4357dd",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/sklearn/utils/validation.py:2739: UserWarning: X does not have valid feature names, but LGBMClassifier was fitted with feature names\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Validation AUC: 0.7426781732230038\n"
+      "Validation AUC: 0.7427294881560009\n"
      ]
     },
     {
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/sklearn/utils/validation.py:2739: UserWarning: X does not have valid feature names, but LGBMClassifier was fitted with feature names\n",
-      "  warnings.warn(\n"
+      "/Users/rik/Documents/VU/DMT/DataMiningTechniquesA2/lgbm_classifier.py:141: SettingWithCopyWarning: \n",
+      "A value is trying to be set on a copy of a slice from a DataFrame.\n",
+      "Try using .loc[row_indexer,col_indexer] = value instead\n",
+      "\n",
+      "See the caveats in the documentation: https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy\n",
+      "  df['score'] = predictions\n"
      ]
     },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Validation NDCG@5: 0.37621275624795153\n"
+      "Validation NDCG@5: 0.3759917362136209\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "(0.7426781732230038, 0.37621275624795153)"
+       "(0.7427294881560009, 0.3759917362136209)"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -191,32 +184,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 17,
    "id": "a6367d17",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/sklearn/utils/validation.py:2739: UserWarning: X does not have valid feature names, but LGBMClassifier was fitted with feature names\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Validation NDCG@5: 0.4455873831934228\n"
+      "Validation NDCG@5: 0.44144673982070093\n"
      ]
     },
     {
      "data": {
       "text/plain": [
-       "0.4455873831934228"
+       "0.44144673982070093"
       ]
      },
-     "execution_count": 19,
+     "execution_count": 17,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -227,52 +212,126 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 18,
    "id": "c1b3fdd1",
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/Users/rik/.pyenv/versions/3.10.12/lib/python3.10/site-packages/sklearn/utils/validation.py:2739: UserWarning: X does not have valid feature names, but LGBMClassifier was fitted with feature names\n",
-      "  warnings.warn(\n"
-     ]
-    },
-    {
      "data": {
       "text/html": [
-       "<div><style>\n",
-       ".dataframe > thead > tr,\n",
-       ".dataframe > tbody > tr {\n",
-       "  text-align: right;\n",
-       "  white-space: pre-wrap;\n",
-       "}\n",
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
        "</style>\n",
-       "<small>shape: (4_959_183, 2)</small><table border=\"1\" class=\"dataframe\"><thead><tr><th>srch_id</th><th>prop_id</th></tr><tr><td>i32</td><td>i32</td></tr></thead><tbody><tr><td>1</td><td>54937</td></tr><tr><td>1</td><td>28181</td></tr><tr><td>1</td><td>99484</td></tr><tr><td>1</td><td>61934</td></tr><tr><td>1</td><td>5543</td></tr><tr><td>&hellip;</td><td>&hellip;</td></tr><tr><td>332787</td><td>29018</td></tr><tr><td>332787</td><td>32019</td></tr><tr><td>332787</td><td>99509</td></tr><tr><td>332787</td><td>94437</td></tr><tr><td>332787</td><td>35240</td></tr></tbody></table></div>"
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>srch_id</th>\n",
+       "      <th>prop_id</th>\n",
+       "      <th>score</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>1</td>\n",
+       "      <td>54937</td>\n",
+       "      <td>0.132118</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>1</td>\n",
+       "      <td>28181</td>\n",
+       "      <td>0.106891</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>12</th>\n",
+       "      <td>1</td>\n",
+       "      <td>61934</td>\n",
+       "      <td>0.087581</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>23</th>\n",
+       "      <td>1</td>\n",
+       "      <td>99484</td>\n",
+       "      <td>0.086846</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>5543</td>\n",
+       "      <td>0.056554</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4959177</th>\n",
+       "      <td>332787</td>\n",
+       "      <td>29018</td>\n",
+       "      <td>0.202499</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4959178</th>\n",
+       "      <td>332787</td>\n",
+       "      <td>32019</td>\n",
+       "      <td>0.200721</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4959182</th>\n",
+       "      <td>332787</td>\n",
+       "      <td>99509</td>\n",
+       "      <td>0.188598</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4959181</th>\n",
+       "      <td>332787</td>\n",
+       "      <td>94437</td>\n",
+       "      <td>0.156132</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4959180</th>\n",
+       "      <td>332787</td>\n",
+       "      <td>35240</td>\n",
+       "      <td>0.106375</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>4959183 rows × 3 columns</p>\n",
+       "</div>"
       ],
       "text/plain": [
-       "shape: (4_959_183, 2)\n",
-       "┌─────────┬─────────┐\n",
-       "│ srch_id ┆ prop_id │\n",
-       "│ ---     ┆ ---     │\n",
-       "│ i32     ┆ i32     │\n",
-       "╞═════════╪═════════╡\n",
-       "│ 1       ┆ 54937   │\n",
-       "│ 1       ┆ 28181   │\n",
-       "│ 1       ┆ 99484   │\n",
-       "│ 1       ┆ 61934   │\n",
-       "│ 1       ┆ 5543    │\n",
-       "│ …       ┆ …       │\n",
-       "│ 332787  ┆ 29018   │\n",
-       "│ 332787  ┆ 32019   │\n",
-       "│ 332787  ┆ 99509   │\n",
-       "│ 332787  ┆ 94437   │\n",
-       "│ 332787  ┆ 35240   │\n",
-       "└─────────┴─────────┘"
+       "         srch_id  prop_id     score\n",
+       "9              1    54937  0.132118\n",
+       "5              1    28181  0.106891\n",
+       "12             1    61934  0.087581\n",
+       "23             1    99484  0.086846\n",
+       "1              1     5543  0.056554\n",
+       "...          ...      ...       ...\n",
+       "4959177   332787    29018  0.202499\n",
+       "4959178   332787    32019  0.200721\n",
+       "4959182   332787    99509  0.188598\n",
+       "4959181   332787    94437  0.156132\n",
+       "4959180   332787    35240  0.106375\n",
+       "\n",
+       "[4959183 rows x 3 columns]"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 18,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/lgbm_classifier.py
+++ b/lgbm_classifier.py
@@ -1,5 +1,3 @@
-# 1. Imports
-import polars as pl
 import numpy as np
 import pandas as pd
 from lightgbm import LGBMClassifier, early_stopping, log_evaluation
@@ -7,15 +5,13 @@ from sklearn.model_selection import GroupKFold
 from sklearn.metrics import roc_auc_score
 
 class LGBMClassifierModel:
-    def __init__(self, df:pl.DataFrame,  **kwargs):
+    def __init__(self, df:pd.DataFrame,  **kwargs):
         self.model = LGBMClassifier(**kwargs)
         self.feature_cols = self.get_feature_cols(df)
-        self.schema = df.select(self.feature_cols).collect_schema()
         # Categorical features should be passed explicitly to the model, these do not include the indentifying columns (srch_id, prop_id)
         self.categorical_features = ["site_id", "visitor_location_country_id", "prop_country_id", "srch_destination_id"]
-        self.categorical_indices = [self.feature_cols.index(c) for c in self.categorical_features]
 
-    def format_and_train(self, train_df:pl.DataFrame) -> None:
+    def format_and_train(self, train_df:pd.DataFrame) -> None:
         """Format the training data and train the model."""
         # Format the data
         X_train, y_train, X_val, y_val, val_idx = self.format_data(train_df)
@@ -24,7 +20,7 @@ class LGBMClassifierModel:
         self.fit(X_train, y_train, X_val, y_val)
         return X_train, y_train, X_val, y_val, val_idx
 
-    def format_data(self, df:pl.DataFrame, target:str = "click_bool", group: str = "srch_id") -> tuple[pl.DataFrame, np.array, pl.DataFrame, np.array, np.array]:
+    def format_data(self, df:pd.DataFrame, target:str = "click_bool", group: str = "srch_id") -> tuple[pd.DataFrame, np.array, pd.DataFrame, np.array, np.array]:
         """Format the data for LightGBM."""
         X = self.get_X(df)
         y = df[target].to_numpy()
@@ -35,12 +31,12 @@ class LGBMClassifierModel:
 
         return X_train, y_train, X_val, y_val, val_idx
     
-    def get_X(self, df:pl.DataFrame) -> np.array:
+    def get_X(self, df:pd.DataFrame) -> pd.DataFrame:
         """Get the feature matrix from the DataFrame."""
-        X = df.select(self.feature_cols).to_numpy()
+        X = df[self.feature_cols]
         return X
 
-    def get_feature_cols(self, df:pl.DataFrame) -> list[str]:
+    def get_feature_cols(self, df:pd.DataFrame) -> list[str]:
         """Get feature columns from the DataFrame. The training set contains multiple columns that are not in the test set."""
         to_exclude = {
             "srch_id",     # group/key for queries
@@ -53,17 +49,17 @@ class LGBMClassifierModel:
         feature_cols = [c for c in df.columns if c not in to_exclude]
         return feature_cols
     
-    def train_val_split(self, X:np.array, y:np.array, groups:np.array) -> tuple[np.array, np.array, np.array, np.array, np.array]:
+    def train_val_split(self, X:pd.DataFrame, y:np.array, groups:np.array) -> tuple[pd.DataFrame, np.array, pd.DataFrame, np.array, np.array]:
         """Split the data into training and validation sets."""
         # Create a group‐aware train/validation split
         gkf = GroupKFold(n_splits=5)
         # Here we take the first fold; you can loop or use more folds
         train_idx, val_idx = next(gkf.split(X, y, groups))
-        X_train, X_val = X[train_idx], X[val_idx]
+        X_train, X_val = X.iloc[train_idx], X.iloc[val_idx]
         y_train, y_val = y[train_idx], y[val_idx]
         return X_train, y_train, X_val, y_val, val_idx
     
-    def fit(self, X_train:np.array, y_train:np.array, X_val:np.array, y_val:np.array, eval_metric: str = "auc", 
+    def fit(self, X_train:pd.DataFrame, y_train:np.array, X_val:pd.DataFrame, y_val:np.array, eval_metric: str = "auc", 
             early_stopping_rounds:int = 50, verbose:int = 20) -> None:
         """Fit the model."""
         # Fit the model
@@ -72,37 +68,37 @@ class LGBMClassifierModel:
             eval_set=[(X_val, y_val)],
             eval_metric=eval_metric,
             callbacks=[early_stopping(early_stopping_rounds), log_evaluation(verbose)],
-            categorical_feature=self.categorical_indices,
+            categorical_feature=self.categorical_features,
         )
 
-    def evaluate_validation(self, X_val:np.array, y_val:np.array, train_df: pl.DataFrame, val_idx) -> float:
+    def evaluate_validation(self, X_val:pd.DataFrame, y_val:np.array, train_df: pd.DataFrame, val_idx) -> float:
         """Evaluate the model."""
         # Get the ROC AUC score
         roc_auc = self.get_roc_auc(X_val, y_val)
 
-        val_df:pl.DataFrame = train_df[val_idx]
+        val_df:pd.DataFrame = train_df.iloc[val_idx]
 
         # Compute NDCG score
         mean_ndcg = self.get_ndcg_score(val_df)
         return roc_auc, mean_ndcg
     
-    def get_ndcg_score(self, df:pl.DataFrame, k:int = 5) -> float:
+    def get_ndcg_score(self, df:pd.DataFrame, k:int = 5) -> float:
         """Get the NDCG score."""
         df = self.add_predictions(df)
-        df = df.select(["srch_id", "click_bool", "score"])
-        df = df.sort(["srch_id", "score"], descending=[False, True])
+        df = df[["srch_id", "click_bool", "score"]]
+        df = df.sort_values(["srch_id", "score"], ascending=[True, False])
 
         # Compute NDCG@k
         mean_ndcg = self.mean_ndcg_at_k(df, k=k)
         print(f"Validation NDCG@{k}:", mean_ndcg)
         return mean_ndcg
 
-    def mean_ndcg_at_k(self, df:pl.DataFrame, k:int=5):
+    def mean_ndcg_at_k(self, df:pd.DataFrame, k:int=5):
         """Compute mean NDCG@k across all srch_ids"""
         ndcgs = []
-        for srch_id, group in df.group_by("srch_id"):
+        for srch_id, group in df.groupby("srch_id"):
             # Relevance is typically click_bool or booking_bool (or a combined score)
-            relevances = group["click_bool"].to_list()  # or use combined click + 5*booking
+            relevances = group["click_bool"].tolist()  # or use combined click + 5*booking
             ndcgs.append(self.ndcg_at_k(relevances, k))
         return np.mean(ndcgs)
     
@@ -117,37 +113,32 @@ class LGBMClassifierModel:
         relevances = np.array(relevances)[:k]
         return np.sum((2 ** relevances - 1) / np.log2(np.arange(2, len(relevances) + 2)))
     
-    def get_roc_auc(self, X_val: np.array, y_val:np.array) -> float:
+    def get_roc_auc(self, X_val: pd.DataFrame, y_val:np.array) -> float:
         """Get the ROC AUC score."""
         y_val_pred = self.model.predict_proba(X_val)[:,1]
         roc_auc = roc_auc_score(y_val, y_val_pred)
         print("Validation AUC:", roc_auc)
         return roc_auc
 
-    def add_predictions(self,df:pl.DataFrame) -> pl.DataFrame:
+    def get_final_predictions(self, df:pd.DataFrame) -> np.array:
+        """Get the property predictions for the test set."""
+        df = self.add_predictions(df)
+        return df[['srch_id', 'prop_id', 'score']]
+    
+    def add_predictions(self,df:pd.DataFrame) -> pd.DataFrame:
         """Add predictions to a DataFrame."""
         predictions = self.predict(df)
         val_df = self.add_predictions_to_df(df, predictions)
         return val_df
-    
-    def add_predictions_to_df(self, df:pl.DataFrame, predictions:np.array) -> pl.DataFrame:
-        """Add predictions to the DataFrame."""
-        df = df.with_columns(pl.Series(name="score", values=predictions))
-        return df.sort(["srch_id", "score"], descending=[False, True])
 
-    def get_final_predictions(self, df:pl.DataFrame) -> np.array:
-        """Get the property predictions for the test set."""
-        predictions = self.predict(df)
-        prop_predictions = self.get_prop_predictions(df, predictions)
-        return prop_predictions
-
-    def predict(self, df:pl.DataFrame) -> np.array:
+    def predict(self, df:pd.DataFrame) -> np.array:
         """Generate predictions on the test set."""
         X = self.get_X(df)
         return self.model.predict_proba(X)[:,1]
     
-    def get_prop_predictions(self, df:pl.DataFrame, predictions:np.array) -> pl.DataFrame:
-        """Get property predictions."""
-        df = df.with_columns(score = pl.Series(predictions))
-        return df.sort(["srch_id", "score"], descending=[False, True]).select(["srch_id", "prop_id"])
+    def add_predictions_to_df(self, df:pd.DataFrame, predictions:np.array) -> pd.DataFrame:
+        """Add predictions to the DataFrame."""
+        df.loc[:, 'score'] = predictions
+        return df.sort_values(["srch_id", "score"], ascending=[True, False])
+    
         


### PR DESCRIPTION
…f Polars

- Updated DataPreparer class to convert Polars DataFrame to Pandas and adjusted data type handling.
- Removed unnecessary imports and methods related to Polars.
- Modified LGBMClassifierModel to accept and process Pandas DataFrames.
- Adjusted data loading in Jupyter notebook to use Pandas for reading parquet files.
- Updated evaluation metrics and predictions handling to align with Pandas DataFrame operations.